### PR TITLE
navigate tabs more easily

### DIFF
--- a/init.vim
+++ b/init.vim
@@ -45,6 +45,10 @@ nnoremap <C-j> <C-w>j
 nnoremap <C-k> <C-w>k
 nnoremap <C-l> <C-w>l
 
+" navigate tabs more easily
+nnoremap <A-h> :tabprevious<CR>
+nnoremap <A-l> :tabnext<CR>
+
 " plugins
 call plug#begin('~/.local/shared/nvim/plugged')
 


### PR DESCRIPTION
Navigate tabs more easily using `Alt+h` and `Alt+l` (instead of `Ctrl+PgUp` and `Ctrl+PgDn`).